### PR TITLE
Add OWNERS templates

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  # TODO: in your repo created from this template, you should replace the
-  # github-admin-team with a list of project owners, see the doc linked above.
-  - github-admin-team
+  - core-ack-team
+  - service-team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners#owners_aliases
 
 aliases:
-  # TODO: remove this alias, it will go stale in your repo, and in your repo
-  # you should have your own set of approvers (see OWNERS)
-  # in the original template repo, we must maintain this list to approve changes
-  # to the template itself
-  github-admin-team:
+  # Always allow the core ACK maintainers to have access to your repository
+  core-ack-team:
     - jaypipes
     - mhausenblas
     - a-hilaly
+    - RedbackThomson
+    - vijtrip2
+  # TODO: Add your team members to your team controller alias
+  service-team: []


### PR DESCRIPTION
Adds the OWNERS and OWNERS_ALIASES template files. Service teams still need to add their particular GitHub aliases in the OWNERS_ALIASES group.