### PR TITLE
replace Broker.Users..Password with SecretKeyRef

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -190,10 +190,10 @@ type SanitizationWarning struct {
 
 // A user associated with the broker.
 type User struct {
-	ConsoleAccess *bool     `json:"consoleAccess,omitempty"`
-	Groups        []*string `json:"groups,omitempty"`
-	Password      *string   `json:"password,omitempty"`
-	Username      *string   `json:"username,omitempty"`
+	ConsoleAccess *bool                           `json:"consoleAccess,omitempty"`
+	Groups        []*string                       `json:"groups,omitempty"`
+	Password      *ackv1alpha1.SecretKeyReference `json:"password,omitempty"`
+	Username      *string                         `json:"username,omitempty"`
 }
 
 // Returns information about the status of the changes pending for the ActiveMQ

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -931,7 +931,7 @@ func (in *User) DeepCopyInto(out *User) {
 	}
 	if in.Password != nil {
 		in, out := &in.Password, &out.Password
-		*out = new(string)
+		*out = new(corev1alpha1.SecretKeyReference)
 		**out = **in
 	}
 	if in.Username != nil {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -66,6 +66,7 @@ func main() {
 		MetricsBindAddress: ackCfg.MetricsAddr,
 		LeaderElection:     ackCfg.EnableLeaderElection,
 		LeaderElectionID:   awsServiceAPIGroup,
+		Namespace:          ackCfg.WatchNamespace,
 	})
 	if err != nil {
 		setupLog.Error(

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         - "$(ACK_LOG_LEVEL)"
         - --resource-tags
         - "$(ACK_RESOURCE_TAGS)"
+        - --watch-namespace
+        - "$(ACK_WATCH_NAMESPACE)"
         image: controller:latest
         name: controller
         ports:

--- a/config/crd/bases/mq.services.k8s.aws_brokers.yaml
+++ b/config/crd/bases/mq.services.k8s.aws_brokers.yaml
@@ -147,7 +147,23 @@ spec:
                         type: string
                       type: array
                     password:
-                      type: string
+                      description: SecretKeyReference combines a k8s corev1.SecretReference
+                        with a specific key within the referred-to Secret
+                      properties:
+                        key:
+                          description: Key is the key within the secret
+                          type: string
+                        name:
+                          description: Name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description: Namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      required:
+                      - key
+                      type: object
                     username:
                       type: string
                   type: object

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -17,6 +17,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get

--- a/generator.yaml
+++ b/generator.yaml
@@ -34,3 +34,5 @@ resources:
           # unnecessarily, we ignore Users for the purposes of comparing
           # resources.
           is_ignored: true
+      Users..Password:
+        is_secret: true

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/mq-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.1.2
+	github.com/aws-controllers-k8s/runtime v0.2.0
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.1.2 h1:prqFY6tlmgsGMZizHvHqDqT1zECRqllepqplOHet4D4=
-github.com/aws-controllers-k8s/runtime v0.1.2/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.2.0 h1:gd0Kq8xGelgkZoNjr8yZbHfpvPA1R+wfMCi1lT4H8x4=
+github.com/aws-controllers-k8s/runtime v0.2.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/resource/broker/resource.go
+++ b/pkg/resource/broker/resource.go
@@ -25,6 +25,11 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
 )
 
+// Hack to avoid import errors during build...
+var (
+	_ = &ackerrors.MissingNameIdentifier
+)
+
 // resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
 // interface
 type resource struct {

--- a/test/e2e/resources/broker_rabbitmq_non_public.yaml
+++ b/test/e2e/resources/broker_rabbitmq_non_public.yaml
@@ -9,7 +9,10 @@ spec:
   engineVersion: $MQ_RABBITMQ_ENGINE_VERSION
   hostInstanceType: $MQ_HOST_INSTANCE_TYPE
   users:
-    - password: adminpassneeds12chars
+    - password:
+        namespace: $ADMIN_USER_PASS_SECRET_NAMESPACE
+        name: $ADMIN_USER_PASS_SECRET_NAME
+        key: $ADMIN_USER_PASS_SECRET_KEY
       groups: []
       consoleAccess: true
       username: admin


### PR DESCRIPTION
Replaces the string `Password` field on the nested `Broker.Spec.Users`
field with a SecretKeyReference so that plain text passwords are not
passed in Broker CRDs.

This commit introduces a manual change to the
config/rbac/cluster-role-controller.yaml file to allow the controller to
read Secrets from the k8s API server. See
aws-controllers-k8s/community#745 for why that was necessary.

Issue aws-controllers-k8s/community#743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
