### PR TITLE
Re-queue if a broker is still in `CREATION_IN_PROGRESS` state

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,0 +1,14 @@
+ack_generate_info:
+  build_date: "2021-06-21T23:48:38Z"
+  build_hash: d5797469ebb582083970136fc08f5de973e9ff1a
+  go_version: go1.16.4 linux/amd64
+  version: v0.2.3
+api_directory_checksum: 47e144cfdead35e46f2c19a5e9444d9b007a73cd
+api_version: v1alpha1
+aws_sdk_go_version: ""
+generator_config_info:
+  file_checksum: 478a7b23a9591f2a8043054f62b79a6fe13b6c0e
+  original_file_name: generator.yaml
+last_modification:
+  reason: API generation
+  timestamp: 2021-06-21 23:48:39.837620379 +0000 UTC

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-06-21T23:48:38Z"
+  build_date: "2021-06-21T23:50:44Z"
   build_hash: d5797469ebb582083970136fc08f5de973e9ff1a
   go_version: go1.16.4 linux/amd64
   version: v0.2.3
@@ -7,8 +7,8 @@ api_directory_checksum: 47e144cfdead35e46f2c19a5e9444d9b007a73cd
 api_version: v1alpha1
 aws_sdk_go_version: ""
 generator_config_info:
-  file_checksum: 478a7b23a9591f2a8043054f62b79a6fe13b6c0e
+  file_checksum: fa56fb1e36e77b89a1cdbaa40e311c356914edb6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-06-21 23:48:39.837620379 +0000 UTC
+  timestamp: 2021-06-21 23:50:46.166341784 +0000 UTC

--- a/apis/v1alpha1/broker.go
+++ b/apis/v1alpha1/broker.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// BrokerSpec defines the desired state of Broker
+// BrokerSpec defines the desired state of Broker.
 type BrokerSpec struct {
 	AuthenticationStrategy *string `json:"authenticationStrategy,omitempty"`
 

--- a/config/crd/bases/mq.services.k8s.aws_brokers.yaml
+++ b/config/crd/bases/mq.services.k8s.aws_brokers.yaml
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BrokerSpec defines the desired state of Broker
+            description: BrokerSpec defines the desired state of Broker.
             properties:
               authenticationStrategy:
                 type: string

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -17,7 +17,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
+  - namespaces
   verbs:
   - get
   - list
@@ -25,7 +25,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
+  - secrets
   verbs:
   - get
   - list

--- a/generator.yaml
+++ b/generator.yaml
@@ -9,6 +9,10 @@ resources:
         template_path: hooks/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/sdk_delete_pre_build_request.go.tpl
+      sdk_read_one_post_set_output:
+        template_path: hooks/sdk_read_one_post_set_output.go.tpl
+      sdk_update_pre_set_output:
+        template_path: hooks/sdk_update_pre_set_output.go.tpl
     renames:
       operations:
         CreateBroker:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/mq-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.2.0
+	github.com/aws-controllers-k8s/runtime v0.2.3
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.2.0 h1:gd0Kq8xGelgkZoNjr8yZbHfpvPA1R+wfMCi1lT4H8x4=
-github.com/aws-controllers-k8s/runtime v0.2.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.2.3 h1:pDDSXOJj5QLlC9OcgnGujeocQEg5U1oqQw3kUSDefLU=
+github.com/aws-controllers-k8s/runtime v0.2.3/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -78,7 +78,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-github.com/go-logr/zapr v0.1.0 h1:h+WVe9j6HAA01niTJPA/kKH0i7e0rLZBCwauQFcRE54=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.1.1 h1:qXBXPDdNncunGs7XeEpsJt8wCjYBygluzfdLO0G5baE=
 github.com/go-logr/zapr v0.1.1/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
@@ -132,7 +131,6 @@ github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -170,7 +168,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -178,7 +175,6 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/resource/broker/manager.go
+++ b/pkg/resource/broker/manager.go
@@ -18,16 +18,16 @@ package broker
 import (
 	"context"
 	"fmt"
-	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/mq"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/mq/mqiface"
@@ -87,6 +87,9 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
+		if observed != nil {
+			return rm.onError(observed, err)
+		}
 		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)

--- a/pkg/resource/broker/sdk.go
+++ b/pkg/resource/broker/sdk.go
@@ -289,6 +289,9 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if brokerCreateInProgress(&resource{ko}) {
+		return &resource{ko}, requeueWaitWhileCreating
+	}
 	return &resource{ko}, nil
 }
 
@@ -587,6 +590,9 @@ func (rm *resourceManager) sdkUpdate(
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
+	// Copy status from latest observed state
+	latestKOStatus := latest.ko.DeepCopy().Status
+	ko.Status = latestKOStatus
 
 	if resp.BrokerId != nil {
 		ko.Status.BrokerID = resp.BrokerId

--- a/pkg/resource/broker/sdk.go
+++ b/pkg/resource/broker/sdk.go
@@ -22,12 +22,14 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/mq"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/mq"
 )
 
 // Hack to avoid import errors during build...
@@ -39,13 +41,17 @@ var (
 	_ = &svcapitypes.Broker{}
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
+	_ = svcsdkapi.New
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
 func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
-) (*resource, error) {
+) (latest *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkFind")
+	defer exit(err)
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.
@@ -58,13 +64,14 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.DescribeBrokerWithContext(ctx, input)
-	rm.metrics.RecordAPICall("READ_ONE", "DescribeBroker", respErr)
-	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
+	var resp *svcsdkapi.DescribeBrokerResponse
+	resp, err = rm.sdkapi.DescribeBrokerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "DescribeBroker", err)
+	if err != nil {
+		if awsErr, ok := ackerr.AWSError(err); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, respErr
+		return nil, err
 	}
 
 	// Merge in the information we read from the API call above to the copy of
@@ -282,7 +289,6 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -311,24 +317,29 @@ func (rm *resourceManager) newDescribeRequestPayload(
 }
 
 // sdkCreate creates the supplied resource in the backend AWS service API and
-// returns a new resource with any fields in the Status field filled in
+// returns a copy of the resource with resource fields (in both Spec and
+// Status) filled in with values from the CREATE API operation's Output shape.
 func (rm *resourceManager) sdkCreate(
 	ctx context.Context,
-	r *resource,
-) (*resource, error) {
-	input, err := rm.newCreateRequestPayload(ctx, r)
+	desired *resource,
+) (created *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkCreate")
+	defer exit(err)
+	input, err := rm.newCreateRequestPayload(ctx, desired)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.CreateBrokerWithContext(ctx, input)
-	rm.metrics.RecordAPICall("CREATE", "CreateBroker", respErr)
-	if respErr != nil {
-		return nil, respErr
+	var resp *svcsdkapi.CreateBrokerResponse
+	resp, err = rm.sdkapi.CreateBrokerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateBroker", err)
+	if err != nil {
+		return nil, err
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
@@ -344,7 +355,6 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -542,7 +552,10 @@ func (rm *resourceManager) sdkUpdate(
 	desired *resource,
 	latest *resource,
 	delta *ackcompare.Delta,
-) (*resource, error) {
+) (updated *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkUpdate")
+	defer exit(err)
 	if brokerCreateFailed(latest) {
 		msg := "Broker state is CREATION_FAILED"
 		setTerminalCondition(desired, corev1.ConditionTrue, &msg, nil)
@@ -565,10 +578,11 @@ func (rm *resourceManager) sdkUpdate(
 		return nil, err
 	}
 
-	resp, respErr := rm.sdkapi.UpdateBrokerWithContext(ctx, input)
-	rm.metrics.RecordAPICall("UPDATE", "UpdateBroker", respErr)
-	if respErr != nil {
-		return nil, respErr
+	var resp *svcsdkapi.UpdateBrokerResponse
+	resp, err = rm.sdkapi.UpdateBrokerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateBroker", err)
+	if err != nil {
+		return nil, err
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
@@ -581,7 +595,6 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	rm.setStatusDefaults(ko)
-
 	return &resource{ko}, nil
 }
 
@@ -688,7 +701,10 @@ func (rm *resourceManager) newUpdateRequestPayload(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) error {
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.sdkDelete")
+	defer exit(err)
 	if brokerDeleteInProgress(r) {
 		return requeueWaitWhileDeleting
 	}
@@ -697,9 +713,9 @@ func (rm *resourceManager) sdkDelete(
 	if err != nil {
 		return err
 	}
-	_, respErr := rm.sdkapi.DeleteBrokerWithContext(ctx, input)
-	rm.metrics.RecordAPICall("DELETE", "DeleteBroker", respErr)
-	return respErr
+	_, err = rm.sdkapi.DeleteBrokerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteBroker", err)
+	return err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/registry.go
+++ b/pkg/resource/registry.go
@@ -24,6 +24,7 @@ import (
 // +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 var (
 	reg = ackrt.NewRegistry()

--- a/templates/hooks/sdk_read_one_post_set_output.go.tpl
+++ b/templates/hooks/sdk_read_one_post_set_output.go.tpl
@@ -1,0 +1,3 @@
+	if brokerCreateInProgress(&resource{ko}) {
+		return &resource{ko}, requeueWaitWhileCreating
+	}

--- a/templates/hooks/sdk_update_pre_set_output.go.tpl
+++ b/templates/hooks/sdk_update_pre_set_output.go.tpl
@@ -1,0 +1,3 @@
+	// Copy status from latest observed state
+    latestKOStatus := latest.ko.DeepCopy().Status
+    ko.Status = latestKOStatus


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/831

This patch adds new generator hooks for `sdkFind` and `sdkUpdate`
methods.
For `sdkFind` the hook will requeue the reconcillation after 30seconds
if a `broker` status is still in `CREATION_IN_PROGRESS`.
For `sdkUpdate` the hook will create a copy of latest `ko` Status into the
the desired one before proceeding in copying the update response fields
 into the desired `ko`.

There are two reasons why we need to copy the CR Status:
- `updateBroker` api call only returns the `BrokerID` and dosen't return
information about the broker state.
- the desired `ko` status is a copy of the observed state by the API
server, which will contain `CREATION_IN_PROGRESS` brokerState in
the CR Status.

Description of changes: 
- Update runtime version to `v0.2.3`
- regenerate controller using `ack-generate` v0.2.3
- Add a post read one hook to requeue whenever a broker is still in `CREATION_IN_PROGRESS` state

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
