### PR TITLE
Bump runtime version and regenerates the controller with `ack-generate` v0.3.1

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-06-21T23:50:44Z"
-  build_hash: d5797469ebb582083970136fc08f5de973e9ff1a
+  build_date: "2021-06-24T15:56:57Z"
+  build_hash: 9c35918f8a98b41ada10cb3aa460dbf463428463
   go_version: go1.16.4 linux/amd64
   version: v0.2.3
 api_directory_checksum: 47e144cfdead35e46f2c19a5e9444d9b007a73cd
 api_version: v1alpha1
-aws_sdk_go_version: ""
+aws_sdk_go_version: v1.38.60
 generator_config_info:
   file_checksum: fa56fb1e36e77b89a1cdbaa40e311c356914edb6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-06-21 23:50:46.166341784 +0000 UTC
+  timestamp: 2021-06-24 15:56:58.608690064 +0000 UTC

--- a/pkg/resource/broker/manager.go
+++ b/pkg/resource/broker/manager.go
@@ -197,7 +197,7 @@ func (rm *resourceManager) onError(
 	r *resource,
 	err error,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, err)
+	r1, updated := rm.updateConditions(r, false, err)
 	if !updated {
 		return r, err
 	}
@@ -217,7 +217,7 @@ func (rm *resourceManager) onError(
 func (rm *resourceManager) onSuccess(
 	r *resource,
 ) (acktypes.AWSResource, error) {
-	r1, updated := rm.updateConditions(r, nil)
+	r1, updated := rm.updateConditions(r, true, nil)
 	if !updated {
 		return r, nil
 	}

--- a/pkg/resource/broker/manager_factory.go
+++ b/pkg/resource/broker/manager_factory.go
@@ -79,6 +79,12 @@ func (f *resourceManagerFactory) IsAdoptable() bool {
 	return true
 }
 
+// RequeueOnSuccessSeconds returns true if the resource should be requeued after specified seconds
+// Default is false which means resource will not be requeued after success.
+func (f *resourceManagerFactory) RequeueOnSuccessSeconds() int {
+	return 0
+}
+
 func newResourceManagerFactory() *resourceManagerFactory {
 	return &resourceManagerFactory{
 		rmCache: map[string]*resourceManager{},

--- a/pkg/resource/broker/resource.go
+++ b/pkg/resource/broker/resource.go
@@ -74,6 +74,11 @@ func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
 }
 
+// ReplaceConditions sets the Conditions status field for the resource
+func (r *resource) ReplaceConditions(conditions []*ackv1alpha1.Condition) {
+	r.ko.Status.Conditions = conditions
+}
+
 // SetObjectMeta sets the ObjectMeta field for the resource
 func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
 	r.ko.ObjectMeta = meta


### PR DESCRIPTION
Regenerates the MQ controller with `ack-generate` v0.3.1 to bring
in runtime `v0.3.0` improvements and features.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
