### PR TITLE
Add additional ec2 inline policy

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:ModifyNetworkInterfaceAttribute",
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
Additional iam `ec2:ModifyNetworkInterfaceAttribute` is required when attaching MQ to a VPC with specific security group. This permission is to modify the ENI and attach the security group.

Fixes #1526