### PR TITLE
feat: Add subnetRefs property to mq broker resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-09-12T19:50:18Z"
-  build_hash: 2944c8772f216656d84ee02d392eaca501274c1e
-  go_version: go1.17.5
-  version: v0.20.1
-api_directory_checksum: e1ee5c7e8dd7cabed0fc81993d5f21d87c1d2561
+  build_date: "2022-11-11T21:57:29Z"
+  build_hash: 18745aa8d1126566776a4748c403ae891b889e9c
+  go_version: go1.19.1
+  version: v0.20.1-7-g18745aa
+api_directory_checksum: f2d41863441b468e097676172b7f9bdc96f8690b
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: db889711567c0f434fa07a6cad1cfeaf0f6a08d6
+  file_checksum: d76f33189fa4873d2a88c79795906bca8b6ce727
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/broker.go
+++ b/apis/v1alpha1/broker.go
@@ -61,7 +61,8 @@ type BrokerSpec struct {
 
 	StorageType *string `json:"storageType,omitempty"`
 
-	SubnetIDs []*string `json:"subnetIDs,omitempty"`
+	SubnetIDs  []*string                                  `json:"subnetIDs,omitempty"`
+	SubnetRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"subnetRefs,omitempty"`
 
 	Tags map[string]*string `json:"tags,omitempty"`
 

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -19,6 +19,11 @@ resources:
           input_fields:
             BrokerName: Name
     fields:
+      SubnetIDs:
+        references:
+          service_name: ec2
+          resource: Subnet
+          path: Status.SubnetID
       BrokerState:
         from:
           operation: DescribeBroker

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -326,6 +326,17 @@ func (in *BrokerSpec) DeepCopyInto(out *BrokerSpec) {
 			}
 		}
 	}
+	if in.SubnetRefs != nil {
+		in, out := &in.SubnetRefs, &out.SubnetRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make(map[string]*string, len(*in))

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -52,6 +53,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = ec2apitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/mq.services.k8s.aws_brokers.yaml
+++ b/config/crd/bases/mq.services.k8s.aws_brokers.yaml
@@ -132,6 +132,22 @@ spec:
                 items:
                   type: string
                 type: array
+              subnetRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef: from: name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               tags:
                 additionalProperties:
                   type: string

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -32,6 +32,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - mq.services.k8s.aws
   resources:
   - brokers

--- a/generator.yaml
+++ b/generator.yaml
@@ -19,6 +19,11 @@ resources:
           input_fields:
             BrokerName: Name
     fields:
+      SubnetIDs:
+        references:
+          service_name: ec2
+          resource: Subnet
+          path: Status.SubnetID
       BrokerState:
         from:
           operation: DescribeBroker

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/aws-controllers-k8s/ec2-controller v0.0.21 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws-controllers-k8s/ec2-controller v0.0.21 h1:5O7/9aED2Tl9OT0TL2rWrc1Ix5V1UxYEgDKAhvFhPJQ=
+github.com/aws-controllers-k8s/ec2-controller v0.0.21/go.mod h1:OMsmJeJ3iQZ1sJgs3hqnjBRnJ3hmTzJUO38W5rxnB5M=
 github.com/aws-controllers-k8s/runtime v0.20.1 h1:L/Huf1shRahx5BqJBCSS5u+vYg3f0Rotsq1jutORpdI=
 github.com/aws-controllers-k8s/runtime v0.20.1/go.mod h1:k7z4qlf6aK1Kzd4ff49wzcyhDKHjWaUpqxrwgl4uS1o=
 github.com/aws/aws-sdk-go v1.44.93 h1:hAgd9fuaptBatSft27/5eBMdcA8+cIMqo96/tZ6rKl8=

--- a/helm/crds/mq.services.k8s.aws_brokers.yaml
+++ b/helm/crds/mq.services.k8s.aws_brokers.yaml
@@ -132,6 +132,22 @@ spec:
                 items:
                   type: string
                 type: array
+              subnetRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef: from: name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               tags:
                 additionalProperties:
                   type: string

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -4,11 +4,19 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: ack-mq-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 {{ else }}
 kind: Role
 metadata:
   creationTimestamp: null
   name: ack-mq-controller
+  labels:
+  {{- range $key, $value := .Values.role.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 {{ end }}
 rules:
@@ -38,6 +46,20 @@ rules:
   - list
   - patch
   - watch
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets/status
+  verbs:
+  - get
+  - list
 - apiGroups:
   - mq.services.k8s.aws
   resources:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -65,6 +65,14 @@
       ],
       "type": "object"
     },
+    "role": {
+      "description": "Role settings",
+      "properties": {
+        "labels": {
+	  "type": "object"
+	}
+      }
+    },
     "metrics": {
       "description": "Metrics settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,6 +28,10 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+
+# If "installScope: cluster" then these labels will be applied to ClusterRole
+role:
+ labels: {}
   
 metrics:
   service:

--- a/pkg/resource/broker/delta.go
+++ b/pkg/resource/broker/delta.go
@@ -273,6 +273,9 @@ func newResourceDelta(
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.SubnetIDs, b.ko.Spec.SubnetIDs) {
 		delta.Add("Spec.SubnetIDs", a.ko.Spec.SubnetIDs, b.ko.Spec.SubnetIDs)
 	}
+	if !reflect.DeepEqual(a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs) {
+		delta.Add("Spec.SubnetRefs", a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	} else if a.ko.Spec.Tags != nil && b.ko.Spec.Tags != nil {

--- a/pkg/resource/broker/references.go
+++ b/pkg/resource/broker/references.go
@@ -17,12 +17,23 @@ package broker
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -36,17 +47,96 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForSubnetIDs(ctx, apiReader, namespace, ko)
+	}
+
+	// If there was an error while resolving any reference, reset all the
+	// resolved values so that they do not get persisted inside etcd
+	if err != nil {
+		ko = rm.concreteResource(res).ko.DeepCopy()
+	}
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Broker) error {
+	if ko.Spec.SubnetRefs != nil && ko.Spec.SubnetIDs != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SubnetIDs", "SubnetRefs")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.Broker) bool {
-	return false
+	return false || (ko.Spec.SubnetRefs != nil)
+}
+
+// resolveReferenceForSubnetIDs reads the resource referenced
+// from SubnetRefs field and sets the SubnetIDs
+// from referenced resource
+func resolveReferenceForSubnetIDs(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Broker,
+) error {
+	if ko.Spec.SubnetRefs != nil &&
+		len(ko.Spec.SubnetRefs) > 0 {
+		resolvedReferences := []*string{}
+		for _, arrw := range ko.Spec.SubnetRefs {
+			arr := arrw.From
+			if arr == nil || arr.Name == nil || *arr.Name == "" {
+				return fmt.Errorf("provided resource reference is nil or empty")
+			}
+			namespacedName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      *arr.Name,
+			}
+			obj := ec2apitypes.Subnet{}
+			err := apiReader.Get(ctx, namespacedName, &obj)
+			if err != nil {
+				return err
+			}
+			var refResourceSynced, refResourceTerminal bool
+			for _, cond := range obj.Status.Conditions {
+				if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceSynced = true
+				}
+				if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceTerminal = true
+				}
+			}
+			if refResourceTerminal {
+				return ackerr.ResourceReferenceTerminalFor(
+					"Subnet",
+					namespace, *arr.Name)
+			}
+			if !refResourceSynced {
+				return ackerr.ResourceReferenceNotSyncedFor(
+					"Subnet",
+					namespace, *arr.Name)
+			}
+			if obj.Status.SubnetID == nil {
+				return ackerr.ResourceReferenceMissingTargetFieldFor(
+					"Subnet",
+					namespace, *arr.Name,
+					"Status.SubnetID")
+			}
+			referencedValue := string(*obj.Status.SubnetID)
+			resolvedReferences = append(resolvedReferences, &referencedValue)
+		}
+		ko.Spec.SubnetIDs = resolvedReferences
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1507

Description of changes:
This will allow the user to specify subnetRefs in the broker

I tested this using the following broker yaml
```yaml
apiVersion: mq.services.k8s.aws/v1alpha1
kind: Broker
metadata:
  name: mq-eks-workshop
spec:
  name: mq-eks-workshop
  deploymentMode: SINGLE_INSTANCE
  engineType: ActiveMQ
  engineVersion: "5.15.8"
  hostInstanceType: "mq.t3.micro"
  publiclyAccessible: false
  autoMinorVersionUpgrade: false
  users:
    - password:
        namespace: default
        name: mq-eks-workshop
        key: password
      groups: []
      consoleAccess: true
      username: admin
  subnetRefs:
    - from: 
        name: private-us-east-1a
  securityGroups:
  - $(ORDERS_SECURITY_GROUP_ID)
```
This PR allows to specify the following section
```yaml
  subnetRefs:
    - from: 
        name: private-us-east-1a
```
The value of `$(ORDERS_SECURITY_GROUP_ID)` is the security group id of one already present in the same vpc.
I will submit another PR to allow the Broker to reference a security group resources

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
