### PR TITLE
Add securityGroupRefs to mq broker

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-11-11T21:57:29Z"
-  build_hash: 18745aa8d1126566776a4748c403ae891b889e9c
+  build_date: "2022-11-15T00:24:53Z"
+  build_hash: f6dd767f12429832bc7b4321fb7b763a9fa997c7
   go_version: go1.19.1
-  version: v0.20.1-7-g18745aa
-api_directory_checksum: f2d41863441b468e097676172b7f9bdc96f8690b
+  version: v0.20.1-9-gf6dd767
+api_directory_checksum: 236360303c9b1377cbc9593078606278a7c59120
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: d76f33189fa4873d2a88c79795906bca8b6ce727
+  file_checksum: a9c6bd3aab21b2e46fc2de93b53534f15bfdf2bb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/broker.go
+++ b/apis/v1alpha1/broker.go
@@ -55,7 +55,8 @@ type BrokerSpec struct {
 	Name *string `json:"name"`
 
 	// +kubebuilder:validation:Required
-	PubliclyAccessible *bool `json:"publiclyAccessible"`
+	PubliclyAccessible *bool                                      `json:"publiclyAccessible"`
+	SecurityGroupRefs  []*ackv1alpha1.AWSResourceReferenceWrapper `json:"securityGroupRefs,omitempty"`
 
 	SecurityGroups []*string `json:"securityGroups,omitempty"`
 

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -19,6 +19,11 @@ resources:
           input_fields:
             BrokerName: Name
     fields:
+      securityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
       SubnetIDs:
         references:
           service_name: ec2

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -299,6 +299,17 @@ func (in *BrokerSpec) DeepCopyInto(out *BrokerSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SecurityGroupRefs != nil {
+		in, out := &in.SecurityGroupRefs, &out.SecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]*string, len(*in))

--- a/config/crd/bases/mq.services.k8s.aws_brokers.yaml
+++ b/config/crd/bases/mq.services.k8s.aws_brokers.yaml
@@ -122,6 +122,22 @@ spec:
                 type: string
               publiclyAccessible:
                 type: boolean
+              securityGroupRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef: from: name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               securityGroups:
                 items:
                   type: string

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -34,6 +34,20 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
   - subnets
   verbs:
   - get

--- a/generator.yaml
+++ b/generator.yaml
@@ -19,6 +19,11 @@ resources:
           input_fields:
             BrokerName: Name
     fields:
+      securityGroups:
+        references:
+          service_name: ec2
+          resource: SecurityGroup
+          path: Status.ID
       SubnetIDs:
         references:
           service_name: ec2

--- a/helm/crds/mq.services.k8s.aws_brokers.yaml
+++ b/helm/crds/mq.services.k8s.aws_brokers.yaml
@@ -122,6 +122,22 @@ spec:
                 type: string
               publiclyAccessible:
                 type: boolean
+              securityGroupRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef: from: name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               securityGroups:
                 items:
                   type: string

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -49,6 +49,20 @@ rules:
 - apiGroups:
   - ec2.services.k8s.aws
   resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
   - subnets
   verbs:
   - get

--- a/pkg/resource/broker/delta.go
+++ b/pkg/resource/broker/delta.go
@@ -260,6 +260,9 @@ func newResourceDelta(
 			delta.Add("Spec.PubliclyAccessible", a.ko.Spec.PubliclyAccessible, b.ko.Spec.PubliclyAccessible)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.SecurityGroupRefs, b.ko.Spec.SecurityGroupRefs) {
+		delta.Add("Spec.SecurityGroupRefs", a.ko.Spec.SecurityGroupRefs, b.ko.Spec.SecurityGroupRefs)
+	}
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.SecurityGroups, b.ko.Spec.SecurityGroups) {
 		delta.Add("Spec.SecurityGroups", a.ko.Spec.SecurityGroups, b.ko.Spec.SecurityGroups)
 	}


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1507

Description of changes:
Add securityGroupRefs to mq broker

Example:
```yaml
apiVersion: mq.services.k8s.aws/v1alpha1
kind: Broker
metadata:
  name: mq-eks-workshop2
spec:
  name: mq-eks-workshop2
  deploymentMode: SINGLE_INSTANCE
  engineType: ActiveMQ
  engineVersion: "5.15.8"
  hostInstanceType: "mq.t3.micro"
  publiclyAccessible: false
  autoMinorVersionUpgrade: false
  users:
    - password:
        namespace: default
        name: mq-eks-workshop
        key: password
      groups: []
      consoleAccess: true
      username: admin
  subnetRefs:
    - from: 
        name: private-us-east-1a
  securityGroupRefs:
    - from: 
        name: mq-eks-workshop
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
