### PR TITLE
Update MQ_HOST_INSTANCE_TYPE to supported instance type

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-03-11T18:53:47Z"
-  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.7
-  version: v0.58.0
+  build_date: "2026-04-22T21:33:12Z"
+  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  go_version: go1.26.2
+  version: v0.58.1
 api_directory_checksum: 524e0af3e7ceea86a3153c12c06091ea924d3410
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -16,5 +16,5 @@ AmazonMQ-specific test variables.
 
 REPLACEMENT_VALUES = {
     "MQ_RABBITMQ_ENGINE_VERSION": "3.13",
-    "MQ_HOST_INSTANCE_TYPE": "mq.t3.micro",
+    "MQ_HOST_INSTANCE_TYPE": "mq.m7g.medium",
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
e2e tests for mq-controller where failing due to the below API error. This PR changes the instance type used by the e2e tests to a supported value.

```
operation error mq: CreateBroker, https response error StatusCode: 400, BadRequestException: Broker engine type [RabbitMQ] does not support host instance type [mq.t3.micro].
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
