### PR TITLE
Add KMS Key reference to Broker encryption options

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -21,6 +21,7 @@ distributed. For any package *NOT* distributed under the terms of the Apache
 License version 2.0, we include the full text of the package's License below.
 
 * `github.com/aws-controllers-k8s/ec2-controller`
+* `github.com/aws-controllers-k8s/kms-controller`
 * `github.com/aws-controllers-k8s/runtime`
 * `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
@@ -1278,34 +1279,25 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-### github.com/aws-controllers-k8s/runtime
+### github.com/aws-controllers-k8s/kms-controller
 
 License Identifier: Apache-2.0
 
 Subdependencies:
+* `github.com/aws-controllers-k8s/runtime`
+* `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
-* `github.com/aws/aws-sdk-go-v2/config`
-* `github.com/aws/aws-sdk-go-v2/credentials`
-* `github.com/aws/aws-sdk-go-v2/service/sts`
+* `github.com/aws/aws-sdk-go-v2/service/kms`
 * `github.com/aws/smithy-go`
-* `github.com/cenkalti/backoff/v4`
 * `github.com/go-logr/logr`
-* `github.com/go-logr/zapr`
-* `github.com/google/go-cmp`
-* `github.com/itchyny/gojq`
-* `github.com/jaypipes/envutil`
-* `github.com/micahhausler/aws-iam-policy`
-* `github.com/pkg/errors`
-* `github.com/prometheus/client_golang`
 * `github.com/spf13/pflag`
 * `github.com/stretchr/testify`
-* `go.uber.org/zap`
 * `k8s.io/api`
 * `k8s.io/apimachinery`
 * `k8s.io/client-go`
-* `k8s.io/klog/v2`
-* `k8s.io/utils`
 * `sigs.k8s.io/controller-runtime`
+* `github.com/aws/aws-sdk-go-v2/config`
+* `github.com/aws/aws-sdk-go-v2/credentials`
 * `github.com/aws/aws-sdk-go-v2/feature/ec2/imds`
 * `github.com/aws/aws-sdk-go-v2/internal/configsources`
 * `github.com/aws/aws-sdk-go-v2/internal/endpoints/v2`
@@ -1314,34 +1306,42 @@ Subdependencies:
 * `github.com/aws/aws-sdk-go-v2/service/internal/presigned-url`
 * `github.com/aws/aws-sdk-go-v2/service/sso`
 * `github.com/aws/aws-sdk-go-v2/service/ssooidc`
+* `github.com/aws/aws-sdk-go-v2/service/sts`
 * `github.com/beorn7/perks`
+* `github.com/cenkalti/backoff/v4`
 * `github.com/cespare/xxhash/v2`
 * `github.com/davecgh/go-spew`
 * `github.com/emicklei/go-restful/v3`
-* `github.com/evanphx/json-patch`
 * `github.com/evanphx/json-patch/v5`
 * `github.com/fsnotify/fsnotify`
 * `github.com/fxamacker/cbor/v2`
+* `github.com/go-logr/zapr`
 * `github.com/go-openapi/jsonpointer`
 * `github.com/go-openapi/jsonreference`
 * `github.com/go-openapi/swag`
 * `github.com/google/btree`
 * `github.com/google/gnostic-models`
+* `github.com/google/go-cmp`
 * `github.com/google/uuid`
+* `github.com/itchyny/gojq`
 * `github.com/itchyny/timefmt-go`
+* `github.com/jaypipes/envutil`
 * `github.com/josharian/intern`
 * `github.com/json-iterator/go`
 * `github.com/mailru/easyjson`
+* `github.com/micahhausler/aws-iam-policy`
 * `github.com/modern-go/concurrent`
 * `github.com/modern-go/reflect2`
 * `github.com/munnerz/goautoneg`
+* `github.com/pkg/errors`
 * `github.com/pmezard/go-difflib`
+* `github.com/prometheus/client_golang`
 * `github.com/prometheus/client_model`
 * `github.com/prometheus/common`
 * `github.com/prometheus/procfs`
-* `github.com/stretchr/objx`
 * `github.com/x448/float16`
 * `go.uber.org/multierr`
+* `go.uber.org/zap`
 * `go.yaml.in/yaml/v2`
 * `go.yaml.in/yaml/v3`
 * `golang.org/x/net`
@@ -1357,25 +1357,27 @@ Subdependencies:
 * `gopkg.in/inf.v0`
 * `gopkg.in/yaml.v3`
 * `k8s.io/apiextensions-apiserver`
+* `k8s.io/klog/v2`
 * `k8s.io/kube-openapi`
+* `k8s.io/utils`
 * `sigs.k8s.io/json`
 * `sigs.k8s.io/randfill`
 * `sigs.k8s.io/structured-merge-diff/v6`
 * `sigs.k8s.io/yaml`
 
+#### github.com/aws-controllers-k8s/runtime
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go
+
+License Identifier: Apache-2.0
+
 #### github.com/aws/aws-sdk-go-v2
 
 License Identifier: Apache-2.0
 
-#### github.com/aws/aws-sdk-go-v2/config
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/credentials
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/sts
+#### github.com/aws/aws-sdk-go-v2/service/kms
 
 License Identifier: Apache-2.0
 
@@ -1383,37 +1385,9 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-
-
 #### github.com/go-logr/logr
 
 License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-#### github.com/micahhausler/aws-iam-policy
-
-License Identifier: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2023, Micah Hausler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-
-
 
 #### github.com/spf13/pflag
 
@@ -1474,8 +1448,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-
-
 #### k8s.io/api
 
 License Identifier: Apache-2.0
@@ -1488,11 +1460,15 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-
-
-
-
 #### sigs.k8s.io/controller-runtime
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/config
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/credentials
 
 License Identifier: Apache-2.0
 
@@ -1528,6 +1504,12 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
+#### github.com/aws/aws-sdk-go-v2/service/sts
+
+License Identifier: Apache-2.0
+
+
+
 
 
 
@@ -1560,36 +1542,6 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-#### github.com/evanphx/json-patch
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### github.com/evanphx/json-patch/v5
 
@@ -1649,6 +1601,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+
 #### github.com/go-openapi/jsonpointer
 
 License Identifier: Apache-2.0
@@ -1668,6 +1622,12 @@ License Identifier: Apache-2.0
 #### github.com/google/gnostic-models
 
 License Identifier: Apache-2.0
+
+
+
+
+
+
 
 
 
@@ -1704,6 +1664,20 @@ SOFTWARE.
 #### github.com/mailru/easyjson
 
 Copyright (c) 2016 Mail.Ru Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#### github.com/micahhausler/aws-iam-policy
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2023, Micah Hausler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -1751,6 +1725,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+
 #### github.com/pmezard/go-difflib
 
 License Identifier: BSD-3-Clause
@@ -1789,32 +1765,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-#### github.com/stretchr/objx
 
-License Identifier: MIT
-
-The MIT License
-
-Copyright (c) 2014 Stretchr, Inc.
-Copyright (c) 2017-2018 objx contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 #### github.com/x448/float16
 
@@ -1841,6 +1792,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
 
 
 
@@ -1940,6 +1893,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+
+
+
+
 #### sigs.k8s.io/randfill
 
 License Identifier: Apache-2.0
@@ -1948,22 +1905,11 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-### github.com/aws/aws-sdk-go
 
-License Identifier: Apache-2.0
 
-Subdependencies:
-* `github.com/jmespath/go-jmespath`
-* `golang.org/x/net`
-* `golang.org/x/text`
 
-### github.com/aws/aws-sdk-go-v2
 
-License Identifier: Apache-2.0
 
-Subdependencies:
-* `github.com/aws/smithy-go`
-* `github.com/jmespath/go-jmespath`
 
 ### github.com/aws/aws-sdk-go-v2/service/mq
 

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2026-06-23T18:24:36Z"
-  build_hash: 7bd233ce4497717ee64e21327c9d52c7c38290fe
+  build_date: "2026-06-23T20:46:48Z"
+  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
   go_version: go1.26.0
-  version: v0.59.1-17-g7bd233c
-api_directory_checksum: 38f42163cc35585cdbc88ad9a6e910661616cfba
+  version: v0.60.0
+api_directory_checksum: e3ed31e062bf8d355afb4e646c5bf75d4731d06e
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:10:14Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
-  version: v0.60.0
-api_directory_checksum: 524e0af3e7ceea86a3153c12c06091ea924d3410
+  build_date: "2026-06-23T18:24:36Z"
+  build_hash: 7bd233ce4497717ee64e21327c9d52c7c38290fe
+  go_version: go1.26.0
+  version: v0.59.1-17-g7bd233c
+api_directory_checksum: 38f42163cc35585cdbc88ad9a6e910661616cfba
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 72d5fe6ac88d647ed6c67869928f3bc12ea6a566
+  file_checksum: fa05039bd65c02c21180550d034bde0800093c49
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -76,6 +76,11 @@ resources:
         late_initialize: {}
       EncryptionOptions:
         late_initialize: {}
+      EncryptionOptions.KMSKeyID:
+        references:
+          service_name: kms
+          resource: Key
+          path: Status.ACKResourceMetadata.ARN
       StorageType:
         late_initialize: {}
       PubliclyAccessible:

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -133,8 +133,10 @@ type DataReplicationMetadataOutput struct {
 
 // Encryption options for the broker.
 type EncryptionOptions struct {
-	KMSKeyID       *string `json:"kmsKeyID,omitempty"`
-	UseAWSOwnedKey *bool   `json:"useAWSOwnedKey,omitempty"`
+	KMSKeyID *string `json:"kmsKeyID,omitempty"`
+	// Reference field for KMSKeyID
+	KMSKeyRef      *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsKeyRef,omitempty"`
+	UseAWSOwnedKey *bool                                    `json:"useAWSOwnedKey,omitempty"`
 }
 
 // Id of the engine version.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -710,6 +710,11 @@ func (in *EncryptionOptions) DeepCopyInto(out *EncryptionOptions) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KMSKeyRef != nil {
+		in, out := &in.KMSKeyRef, &out.KMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.UseAWSOwnedKey != nil {
 		in, out := &in.UseAWSOwnedKey, &out.UseAWSOwnedKey
 		*out = new(bool)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -58,6 +59,7 @@ func init() {
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
 	_ = ec2apitypes.AddToScheme(scheme)
+	_ = kmsapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/mq.services.k8s.aws_brokers.yaml
+++ b/config/crd/bases/mq.services.k8s.aws_brokers.yaml
@@ -79,6 +79,20 @@ spec:
                 properties:
                   kmsKeyID:
                     type: string
+                  kmsKeyRef:
+                    description: Reference field for KMSKeyID
+                    properties:
+                      from:
+                        description: |-
+                          AWSResourceReference provides all the values necessary to reference another
+                          k8s resource for finding the identifier(Id/ARN/Name)
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                    type: object
                   useAWSOwnedKey:
                     type: boolean
                 type: object

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -33,6 +33,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - mq.services.k8s.aws
   resources:
   - brokers

--- a/generator.yaml
+++ b/generator.yaml
@@ -76,6 +76,11 @@ resources:
         late_initialize: {}
       EncryptionOptions:
         late_initialize: {}
+      EncryptionOptions.KMSKeyID:
+        references:
+          service_name: kms
+          resource: Key
+          path: Status.ACKResourceMetadata.ARN
       StorageType:
         late_initialize: {}
       PubliclyAccessible:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/aws-controllers-k8s/ec2-controller v0.0.21
+	github.com/aws-controllers-k8s/kms-controller v1.3.2
 	github.com/aws-controllers-k8s/runtime v0.60.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/aws-controllers-k8s/ec2-controller v0.0.21 h1:5O7/9aED2Tl9OT0TL2rWrc1Ix5V1UxYEgDKAhvFhPJQ=
 github.com/aws-controllers-k8s/ec2-controller v0.0.21/go.mod h1:OMsmJeJ3iQZ1sJgs3hqnjBRnJ3hmTzJUO38W5rxnB5M=
+github.com/aws-controllers-k8s/kms-controller v1.3.2 h1:Wp4caGNd5dHV6OHGMddouV/EVVT/m+Rv12VB14lUAXA=
+github.com/aws-controllers-k8s/kms-controller v1.3.2/go.mod h1:sr6ArkYgVGTAQBa1sIqgdt4DQyjOtsehVC3Vn4DYj2g=
 github.com/aws-controllers-k8s/runtime v0.60.0 h1:obCtliXzv+HqpVwEHZ388wC7uBDVdGWeuK8DMHcPcIE=
 github.com/aws-controllers-k8s/runtime v0.60.0/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=

--- a/helm/crds/mq.services.k8s.aws_brokers.yaml
+++ b/helm/crds/mq.services.k8s.aws_brokers.yaml
@@ -79,6 +79,20 @@ spec:
                 properties:
                   kmsKeyID:
                     type: string
+                  kmsKeyRef:
+                    description: Reference field for KMSKeyID
+                    properties:
+                      from:
+                        description: |-
+                          AWSResourceReference provides all the values necessary to reference another
+                          k8s resource for finding the identifier(Id/ARN/Name)
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                    type: object
                   useAWSOwnedKey:
                     type: boolean
                 type: object

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -80,6 +80,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - mq.services.k8s.aws
   resources:
   - brokers

--- a/pkg/resource/broker/references.go
+++ b/pkg/resource/broker/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -31,6 +32,9 @@ import (
 
 	svcapitypes "github.com/aws-controllers-k8s/mq-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
@@ -44,6 +48,12 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.EncryptionOptions != nil {
+		if ko.Spec.EncryptionOptions.KMSKeyRef != nil {
+			ko.Spec.EncryptionOptions.KMSKeyID = nil
+		}
+	}
 
 	if len(ko.Spec.SecurityGroupRefs) > 0 {
 		ko.Spec.SecurityGroups = nil
@@ -72,6 +82,12 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForEncryptionOptions_KMSKeyID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForSecurityGroups(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -91,12 +107,111 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Broker) error {
 
+	if ko.Spec.EncryptionOptions != nil {
+		if ko.Spec.EncryptionOptions.KMSKeyRef != nil && ko.Spec.EncryptionOptions.KMSKeyID != nil {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("EncryptionOptions.KMSKeyID", "EncryptionOptions.KMSKeyRef")
+		}
+	}
+
 	if len(ko.Spec.SecurityGroupRefs) > 0 && len(ko.Spec.SecurityGroups) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("SecurityGroups", "SecurityGroupRefs")
 	}
 
 	if len(ko.Spec.SubnetRefs) > 0 && len(ko.Spec.SubnetIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("SubnetIDs", "SubnetRefs")
+	}
+	return nil
+}
+
+// resolveReferenceForEncryptionOptions_KMSKeyID reads the resource referenced
+// from EncryptionOptions.KMSKeyRef field and sets the EncryptionOptions.KMSKeyID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForEncryptionOptions_KMSKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Broker,
+) (hasReferences bool, err error) {
+	if ko.Spec.EncryptionOptions != nil {
+		if ko.Spec.EncryptionOptions.KMSKeyRef != nil && ko.Spec.EncryptionOptions.KMSKeyRef.From != nil {
+			hasReferences = true
+			arr := ko.Spec.EncryptionOptions.KMSKeyRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: EncryptionOptions.KMSKeyRef")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &kmsapitypes.Key{}
+			if err := getReferencedResourceState_Key(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.EncryptionOptions.KMSKeyID = (*string)(obj.Status.ACKResourceMetadata.ARN)
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Key looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Key(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *kmsapitypes.Key,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Key",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Key",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Key",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Key",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
 }


### PR DESCRIPTION
Description of changes:
Adds a cross-resource reference from `Broker.encryptionOptions.kmsKeyID` to the ACK `kms/Key` resource, allowing the KMS encryption key to be resolved via `kmsKeyRef`.

Generated with code-generator `v0.60.0` / runtime `v0.60.0`, `AWS_SDK_GO_VERSION=v1.34.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
